### PR TITLE
Introduce authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,15 @@ tags:
   - thanks to the Internet
 categories:
   - futurama
+  - dexter
 readingTime: 10 Minutes
+author:
+  link: /category/dexter
+  name: Dexter
+  gravatar: 2bfa103a13c88b5ffd26da6f982f11df
 ---
 ```
 
 The post intro uses the `<!-- more -->` tag.
 
 ## Caveats
-
-* For simplicity this theme doesn't support multiple authors

--- a/blog/.vuepress/theme/layouts/Post.vue
+++ b/blog/.vuepress/theme/layouts/Post.vue
@@ -13,18 +13,18 @@
 
           <div class="post-full-byline">
             <section class="post-full-byline-content">
-              <ul class="author-list" v-if="current.author && gravatar">
+              <ul class="author-list" v-if="author">
                 <li class="author-list-item">
                   <div class="author-name-tooltip">
-                    {{ current.author.name }}
+                    {{ author.name }}
                   </div>
-                  <a class="static-avatar" :href="current.author.link">
-                    <img class="author-profile-image" :src="gravatar" :alt="current.author.name">
+                  <a class="static-avatar" :href="author.link">
+                    <img class="author-profile-image" :src="author.gravatar" :alt="author.name">
                   </a>
                 </li>
               </ul>
               <section class="post-full-byline-meta">
-                <h4 v-if="current.author"><a :href="current.author.link">{{ current.author.name }}</a></h4>
+                <h4 v-if="author"><a :href="author.link">{{ author.name }}</a></h4>
                 <div class="byline-meta-content">
                   <time
                     v-if="datetime"
@@ -61,7 +61,7 @@ import { head, kebabCase } from "lodash";
 
 export default {
   computed: {
-    ...mapGetters(["current", "blog"]),
+    ...mapGetters(["current", "blog", "author"]),
 
     datetime() {
       return (
@@ -89,16 +89,6 @@ export default {
         "background-image": `url(${this.$withBase(this.current.image)})`
       };
     },
-
-    gravatar () {
-      if (this.current.author.gravatar) {
-        return '//www.gravatar.com/avatar/' + this.current.author.gravatar + '?s=250&d=mm&r=x'
-      } else if (this.blog.defaultAuthorGravatar) {
-        return '//www.gravatar.com/avatar/' + this.blog.defaultAuthorGravatar + '?s=250&d=mm&r=x'
-      } else {
-        return false
-      }
-    }
   },
   methods: {
     kebabCase,

--- a/blog/.vuepress/theme/layouts/Post.vue
+++ b/blog/.vuepress/theme/layouts/Post.vue
@@ -13,7 +13,7 @@
 
           <div class="post-full-byline">
             <section class="post-full-byline-content">
-              <ul class="author-list" v-if="current.author">
+              <ul class="author-list" v-if="current.author && gravatar">
                 <li class="author-list-item">
                   <div class="author-name-tooltip">
                     {{ current.author.name }}
@@ -96,7 +96,7 @@ export default {
       } else if (this.blog.defaultAuthorGravatar) {
         return '//www.gravatar.com/avatar/' + this.blog.defaultAuthorGravatar + '?s=250&d=mm&r=x'
       } else {
-        return '//www.gravatar.com/avatar/2bfa103a13c88b5ffd26da6f982f11df?s=250&d=mm&r=x'
+        return false
       }
     }
   },

--- a/blog/.vuepress/theme/layouts/Post.vue
+++ b/blog/.vuepress/theme/layouts/Post.vue
@@ -13,7 +13,18 @@
 
           <div class="post-full-byline">
             <section class="post-full-byline-content">
+              <ul class="author-list" v-if="current.author">
+                <li class="author-list-item">
+                  <div class="author-name-tooltip">
+                    {{ current.author.name }}
+                  </div>
+                  <a class="static-avatar" :href="current.author.link">
+                    <img class="author-profile-image" :src="gravatar" :alt="current.author.name">
+                  </a>
+                </li>
+              </ul>
               <section class="post-full-byline-meta">
+                <h4 v-if="current.author"><a :href="current.author.link">{{ current.author.name }}</a></h4>
                 <div class="byline-meta-content">
                   <time
                     v-if="datetime"
@@ -50,7 +61,7 @@ import { head, kebabCase } from "lodash";
 
 export default {
   computed: {
-    ...mapGetters(["current"]),
+    ...mapGetters(["current", "blog"]),
 
     datetime() {
       return (
@@ -77,6 +88,16 @@ export default {
       return {
         "background-image": `url(${this.$withBase(this.current.image)})`
       };
+    },
+
+    gravatar () {
+      if (this.current.author.gravatar) {
+        return '//www.gravatar.com/avatar/' + this.current.author.gravatar + '?s=250&d=mm&r=x'
+      } else if (this.blog.defaultAuthorGravatar) {
+        return '//www.gravatar.com/avatar/' + this.blog.defaultAuthorGravatar + '?s=250&d=mm&r=x'
+      } else {
+        return '//www.gravatar.com/avatar/2bfa103a13c88b5ffd26da6f982f11df?s=250&d=mm&r=x'
+      }
     }
   },
   methods: {

--- a/blog/.vuepress/theme/layouts/Posts.vue
+++ b/blog/.vuepress/theme/layouts/Posts.vue
@@ -2,7 +2,7 @@
   <main id="site-main" class="site-main outer">
     <div class="inner posts">
       <div class="post-feed">
-        <card v-for="(post, index) in posts" :post="post" :key="index" :large="!index % 6" />
+        <card v-for="(post, index) in posts" :post="post" :key="index" :large="!index % 6" :blog="blog" />
       </div>
     </div>
   </main>
@@ -15,6 +15,6 @@
 
   export default {
     components: { Card, Error },
-    computed: mapGetters(['posts'])
+    computed: mapGetters(['posts', 'blog'])
   }
 </script>

--- a/blog/.vuepress/theme/partials/Card.vue
+++ b/blog/.vuepress/theme/partials/Card.vue
@@ -14,7 +14,18 @@
           </section>
         </a>
         <footer class="post-card-meta">
+          <ul class="author-list-item" v-if="post.author">
+            <li class="author-list-item">
+              <div class="author-name-tooltip">
+                {{ post.author.name }}
+              </div>
+              <a class="static-avatar" :href="post.author.link">
+                <img class="author-profile-image" :src="authorImg" :alt="post.author.name">
+              </a>
+            </li>
+          </ul>
           <div class="post-card-byline-content">
+            <span v-if="post.author"><a :href="post.author.link">{{ post.author.name }}</a></span>
             <span class="post-card-byline-date">
               <time v-if="datetime" :datetime="datetime">{{ localeDate }}</time> <span v-if=" post.readingTime" class="bull">&bull;</span> {{ post.readingTime }}</span>
             </span>
@@ -28,7 +39,7 @@
   import striptags from 'striptags'
 
   export default {
-    props: ['post', 'large'],
+    props: ['post', 'large', 'blog'],
     computed: {
       imageStyle () {
         return {
@@ -43,6 +54,15 @@
       localeDate () {
         return this.post.publish && new Date(this.post.publish).toLocaleDateString()
       },
+      authorImg () {
+        if (this.post.img) {
+          return this.post.img
+        } else if (this.blog.defaultAuthorImg) {
+          return this.blog.defaultAuthorImg
+        } else {
+          return '//www.gravatar.com/avatar/2bfa103a13c88b5ffd26da6f982f11df?s=250&d=mm&r=x'
+        }
+      }
     },
     methods: {
       striptags

--- a/blog/.vuepress/theme/partials/Card.vue
+++ b/blog/.vuepress/theme/partials/Card.vue
@@ -14,13 +14,13 @@
           </section>
         </a>
         <footer class="post-card-meta">
-          <ul class="author-list-item" v-if="post.author">
+          <ul class="author-list" v-if="post.author">
             <li class="author-list-item">
               <div class="author-name-tooltip">
                 {{ post.author.name }}
               </div>
               <a class="static-avatar" :href="post.author.link">
-                <img class="author-profile-image" :src="authorImg" :alt="post.author.name">
+                <img class="author-profile-image" :src="gravatar" :alt="post.author.name">
               </a>
             </li>
           </ul>
@@ -54,11 +54,11 @@
       localeDate () {
         return this.post.publish && new Date(this.post.publish).toLocaleDateString()
       },
-      authorImg () {
-        if (this.post.img) {
-          return this.post.img
-        } else if (this.blog.defaultAuthorImg) {
-          return this.blog.defaultAuthorImg
+      gravatar () {
+        if (this.post.author.gravatar) {
+          return '//www.gravatar.com/avatar/' + this.post.author.gravatar + '?s=250&d=mm&r=x'
+        } else if (this.blog.defaultAuthorGravatar) {
+          return '//www.gravatar.com/avatar/' + this.blog.defaultAuthorGravatar + '?s=250&d=mm&r=x'
         } else {
           return '//www.gravatar.com/avatar/2bfa103a13c88b5ffd26da6f982f11df?s=250&d=mm&r=x'
         }

--- a/blog/.vuepress/theme/partials/Card.vue
+++ b/blog/.vuepress/theme/partials/Card.vue
@@ -14,7 +14,7 @@
           </section>
         </a>
         <footer class="post-card-meta">
-          <ul class="author-list" v-if="post.author">
+          <ul class="author-list" v-if="post.author && gravatar">
             <li class="author-list-item">
               <div class="author-name-tooltip">
                 {{ post.author.name }}
@@ -60,7 +60,7 @@
         } else if (this.blog.defaultAuthorGravatar) {
           return '//www.gravatar.com/avatar/' + this.blog.defaultAuthorGravatar + '?s=250&d=mm&r=x'
         } else {
-          return '//www.gravatar.com/avatar/2bfa103a13c88b5ffd26da6f982f11df?s=250&d=mm&r=x'
+          return false
         }
       }
     },

--- a/blog/.vuepress/theme/partials/Card.vue
+++ b/blog/.vuepress/theme/partials/Card.vue
@@ -14,7 +14,7 @@
           </section>
         </a>
         <footer class="post-card-meta">
-          <ul class="author-list" v-if="post.author && gravatar">
+          <ul class="author-list" v-if="post.author">
             <li class="author-list-item">
               <div class="author-name-tooltip">
                 {{ post.author.name }}
@@ -55,13 +55,8 @@
         return this.post.publish && new Date(this.post.publish).toLocaleDateString()
       },
       gravatar () {
-        if (this.post.author.gravatar) {
-          return '//www.gravatar.com/avatar/' + this.post.author.gravatar + '?s=250&d=mm&r=x'
-        } else if (this.blog.defaultAuthorGravatar) {
-          return '//www.gravatar.com/avatar/' + this.blog.defaultAuthorGravatar + '?s=250&d=mm&r=x'
-        } else {
-          return false
-        }
+          const hash = this.post.author.gravatar ? this.post.author.gravatar : this.blog.defaultAuthorGravatar
+          return '//www.gravatar.com/avatar/' + hash + '?s=250&d=mm&r=x'
       }
     },
     methods: {

--- a/blog/.vuepress/theme/store/getters.js
+++ b/blog/.vuepress/theme/store/getters.js
@@ -15,5 +15,7 @@ export default {
   footer: getOr([], 'footer'),
   nav: getOr([], 'nav'),
 
-  social: getOr([], 'social')
+  social: getOr([], 'social'),
+
+  author: getOr(null, 'author')
 }

--- a/blog/.vuepress/theme/store/mutations.js
+++ b/blog/.vuepress/theme/store/mutations.js
@@ -1,7 +1,7 @@
 import { pick, get } from 'lodash'
 
 import types from './types'
-import { formatPages, formatPage, type, header, posts, footer, social, navigation } from './utils'
+import { formatPages, formatPage, type, header, posts, footer, social, navigation, author } from './utils'
 
 export default {
   [types.SITE_UPDATE]: (state, site) => {
@@ -12,6 +12,7 @@ export default {
     state.index = formatPages(get(site, 'pages', []))
     state.footer = footer(state)
     state.social = social(site)
+    state.author = author(state)
   },
 
   [types.PAGE_UPDATE]: (state, page) => {

--- a/blog/.vuepress/theme/store/state.js
+++ b/blog/.vuepress/theme/store/state.js
@@ -21,5 +21,6 @@ export default {
   type: null,
   posts: [],
   footer: [],
-  social: []
+  social: [],
+  author: null
 }

--- a/blog/.vuepress/theme/store/utils.js
+++ b/blog/.vuepress/theme/store/utils.js
@@ -137,3 +137,13 @@ export const header = state => {
       }
   }
 }
+
+export const author = state => {
+  if(state.current.author) {
+    var author = state.current.author;
+    const hash = state.current.author.gravatar ? state.current.author.gravatar : state.blog.defaultAuthorGravatar;
+    author.gravatar = '//www.gravatar.com/avatar/' + hash + '?s=250&d=mm&r=x';
+    return author;
+  }
+  return null;
+}

--- a/blog/posts/dexter/nobodys-taxi-service.md
+++ b/blog/posts/dexter/nobodys-taxi-service.md
@@ -9,6 +9,9 @@ tags:
 categories:
   - dexter
 readingTime: 9 Minutes
+author:
+  link: /author/test
+  name: test
 ---
 
 The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant. Sorry, checking all the water in this area; there's an escaped fish.
@@ -54,3 +57,26 @@ All I've got to do is pass as an ordinary human being. Simple. What could possib
 I am the Doctor, and you are the Daleks! You know when grown-ups tell you 'everything's going to be fine' and you think they're probably lying to make you feel better? I'm nobody's taxi service; I'm not gonna be there to catch you every time you feel like jumping out of a spaceship.
 
 You hit me with a cricket bat. You hit me with a cricket bat. It's art! A statement on modern society, 'Oh Ain't Modern Society Awful?'! They're not aliens, they're Earth…liens! Sorry, checking all the water in this area; there's an escaped fish.
+
+```php
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = new User([
+            'email' => 'test@example.com',
+            'name' => 'testuser',
+            'password' => '123456',
+        ]);
+        $user->save();
+        $this->token = auth()->login($user);
+
+        Mailaddress::create([
+            'address' => 'test@example.com'
+        ]);
+        Mailaddress::create([
+            'address' => 'test2@example.com',
+            'company_id' => 1
+        ]);
+    }
+```

--- a/blog/posts/dexter/nobodys-taxi-service.md
+++ b/blog/posts/dexter/nobodys-taxi-service.md
@@ -10,8 +10,9 @@ categories:
   - dexter
 readingTime: 9 Minutes
 author:
-  link: /author/test
-  name: test
+  link: /category/dexter
+  name: Dexter
+  gravatar: 2bfa103a13c88b5ffd26da6f982f11df
 ---
 
 The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant. Sorry, checking all the water in this area; there's an escaped fish.
@@ -57,26 +58,3 @@ All I've got to do is pass as an ordinary human being. Simple. What could possib
 I am the Doctor, and you are the Daleks! You know when grown-ups tell you 'everything's going to be fine' and you think they're probably lying to make you feel better? I'm nobody's taxi service; I'm not gonna be there to catch you every time you feel like jumping out of a spaceship.
 
 You hit me with a cricket bat. You hit me with a cricket bat. It's art! A statement on modern society, 'Oh Ain't Modern Society Awful?'! They're not aliens, they're Earth…liens! Sorry, checking all the water in this area; there's an escaped fish.
-
-```php
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $user = new User([
-            'email' => 'test@example.com',
-            'name' => 'testuser',
-            'password' => '123456',
-        ]);
-        $user->save();
-        $this->token = auth()->login($user);
-
-        Mailaddress::create([
-            'address' => 'test@example.com'
-        ]);
-        Mailaddress::create([
-            'address' => 'test2@example.com',
-            'company_id' => 1
-        ]);
-    }
-```


### PR DESCRIPTION
With this PR it is possible to enter an author for a post.

New fields for frontmatter:

```
author:
  link: /category/dexter
  name: Dexter
  gravatar: 2bfa103a13c88b5ffd26da6f982f11df
```

Mandatory fields (if `author` is added):
* `name` (The full name/display name of the author)
* `link` (Link to details about the author or a post list. For the post list I would recommend using a category with the same name as the author)

`gravatar` is not mandatory. It is simply not shown if one does not specify any. It is also possible to define a default gravatar for the whole blog in `themeConfig.defaultAuthorGravatar`.
I use only the hashes there to not disclose email addresses.

If `author` is not present in frontmatter there is not author shown for the post.