### PR TITLE
Introduce optional Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ module.exports = {
       xing: 'https://xing.de',
       instagram: 'https://instagram.com',
       linkedin: 'https://linkedin.com'
-    }
+    },
+
+    search: false
   }
 }
 ```

--- a/blog/.vuepress/data/config.json
+++ b/blog/.vuepress/data/config.json
@@ -40,6 +40,7 @@
     "social": {
       "github": "https://github.com/alexander-heimbuch/vuepress-theme-casper",
       "twitter": "https://twitter.com/zusatzstoff"
-    }
+    },
+    "search": true
   }
 }

--- a/blog/.vuepress/theme/Layout.vue
+++ b/blog/.vuepress/theme/Layout.vue
@@ -74,4 +74,7 @@ export default {
     min-width: 100%;
     max-width: 100%;
   }
+  .search-box input {
+    width: 20rem;
+  }
 </style>

--- a/blog/.vuepress/theme/index.js
+++ b/blog/.vuepress/theme/index.js
@@ -1,0 +1,8 @@
+module.exports = () => {
+
+    return {
+        plugins: [
+            '@vuepress/search',
+        ]
+    }
+}

--- a/blog/.vuepress/theme/partials/Navigation.vue
+++ b/blog/.vuepress/theme/partials/Navigation.vue
@@ -1,7 +1,7 @@
 <template>
-  <nav class="site-nav">
-    <div class="site-nav-left-wrapper">
-      <div class="site-nav-left">
+  <nav class="site-nav" style="overflow: visible;">
+    <div class="site-nav-left-wrapper" style="height: 100%">
+      <div class="site-nav-left" style="margin-top: auto;">
         <router-link v-if="!isHome && blog.logo" class="site-nav-logo" to="/">
           <img :src="$withBase(blog.logo)" :alt="blog.title" />
         </router-link>
@@ -20,6 +20,7 @@
       </div>
     </div>
     <div class="site-nav-right">
+      <SearchBox v-if="blog.search" />
       <div class="social-links">
         <social-link
           v-for="(channel, index) in social"
@@ -36,9 +37,10 @@
 import { mapGetters } from "vuex";
 
 import SocialLink from "./SocialLink";
+import SearchBox from '@SearchBox'
 
 export default {
-  components: { SocialLink },
+  components: { SocialLink, SearchBox },
   computed: {
     ...mapGetters(["blog", "type", "social", "nav"]),
     isHome() {


### PR DESCRIPTION
Adds the possibility to enable the standard vuePress search by setting the `search` parameter to `true`.

With this, also the [vuepress-plugin-fulltext-search](https://www.npmjs.com/package/vuepress-plugin-fulltext-search) works.